### PR TITLE
Simplify build

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -3,8 +3,10 @@ name: Pre Merge Checks
 on:
   push:
     branches:
-      - master
+      - "**"      # run on push to ANY branch (assuming only maintainer controls that)
   pull_request:
+    branches:
+      - "**"      # run on PRs targeting ANY branch (assuming we check the Gradle wrapper first)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Migrate old workflows (which don't work) to new versions. A side effect - simplify gradle run by using just Gradle wrapper instead of action wrapper