### PR TITLE
change group name

### DIFF
--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -20,7 +20,7 @@ jobs:
     environment:
       # This job must only run in Publishing environment. It is protected from the majority of runs, which prevents Gradle secrets leakage
       name: Publishing
-      url: https://github.com/Gradle-Cloud/gradle-helm-plugin/settings/environments/10298625189/edit
+      url: https://github.com/build.extensions.oss/gradle-helm-plugin/settings/environments/10298625189/edit
 
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle#using-the-gradle-starter-workflow

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
     environment:
       # This job must only run in Publishing environment. It is protected from the majority of runs, which prevents Gradle secrets leakage
       name: Publishing
-      url: https://github.com/Gradle-Cloud/gradle-helm-plugin/settings/environments/10298625189/edit
+      url: https://github.com/build.extensions.oss/gradle-helm-plugin/settings/environments/10298625189/edit
 
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle#using-the-gradle-starter-workflow
@@ -53,7 +53,7 @@ jobs:
       - name: Publish the project
         # Several items:
         # 1. Secrets are uploaded via https://docs.github.com/en/actions/security-guides/encrypted-secrets
-        #    Correct them on https://github.com/Gradle-Cloud/gradle-helm-plugin/settings/environments/10298625189/edit
+        #    Correct them on https://github.com/build.extensions.oss/gradle-helm-plugin/settings/environments/10298625189/edit
         #    Note!!!: these secrets must be in Publishing environment only
         # 2. We physically publish from master branch only. From other branches we can validate workflow.
         #    Please note - 'Publishing' environment is allowed to be used only in main branches, however that can be bypassed by admins (as expected) for publication testing

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@
 
 ## Quick Start
 
-Add `io.github.gradle-cloud.helm` to your Gradle project:
+Add `io.github.build.extensions.oss.helm` to your Gradle project:
 
 ```gradle
 plugins {
-    id 'io.github.gradle-cloud.helm' version '2.2.0'
+    id 'io.github.build.extensions.oss.helm' version '2.2.0'
 }
 ```
 
 ```gradle
 plugins {
-    id("io.github.gradle-cloud.helm") version "2.2.0"
+    id("io.github.build.extensions.oss.helm") version "2.2.0"
 }
 ```
 
@@ -64,7 +64,7 @@ plugins {
 This repository is a fork of [Citi/gradle-helm-plugin](https://github.com/Citi/gradle-helm-plugin), which is a
 of [unbroken-dome/gradle-helm-plugin](https://github.com/unbroken-dome/gradle-helm-plugin).
 
-The version [v2.2.0](https://github.com/Gradle-Cloud/gradle-helm-plugin/releases/tag/v2.2.0) has exactly the same code
+The version [v2.2.0](https://github.com/build.extensions.oss/gradle-helm-plugin/releases/tag/v2.2.0) has exactly the same code
 with version [2.2.0](https://github.com/Citi/gradle-helm-plugin/releases/tag/2.2.0)
 of [Citi/gradle-helm-plugin](https://github.com/Citi/gradle-helm-plugin). Therefore, first please use that version. All
 Java/Kotlin packages are the same, so the plugin should be fully compatible.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,14 @@
 # These two properties define public coordinates of the plugin. There are several restrictions from Gradle:
-# 1. Repositories on GitHub must use io.github and not con.github. You can use that for maven artefacts, but not for Gradle plugins.
+# 1. Repositories on GitHub must use io.github and not com.github. You can use that for maven artefacts, but not for Gradle plugins.
 # 2. Plugin group must match with plugin name.
 # 3. We apply the same group and prefix for all plugins (we have 4 of them)
+# 4. We can't use Gradle in GitHub organization name, because that might conflict with Gradle company trademarks.
 # Consequences:
 # 1. We try to use matching prefixes/groups in the projects
 # 2. We copy-paste values in test to make them more independent. E.g. it is easier to read a small test than understanding our infrastructure.
-plugin.prefix=io.github.gradle-cloud
-group=io.github.gradle-cloud.plugins.helm
-github.url=https://github.com/Gradle-Cloud/gradle-helm-plugin
+plugin.prefix=io.github.build.extensions.oss
+group=io.github.build.extensions.oss.helm
+github.url=https://github.com/build.extensions.oss/gradle-helm-plugin
 
 version=2.2.0
 test.maxParallelForks=4

--- a/helm-publish-plugin/src/functionalTest/resources/test/artifactory-publish/build.gradle
+++ b/helm-publish-plugin/src/functionalTest/resources/test/artifactory-publish/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'io.github.gradle-cloud.helm'
-    id 'io.github.gradle-cloud.helm-publish'
+    id 'io.github.build.extensions.oss.helm'
+    id 'io.github.build.extensions.oss.helm-publish'
 }
 
 helm {

--- a/helm-publish-plugin/src/functionalTest/resources/test/only-helm-publish-plugin/build.gradle
+++ b/helm-publish-plugin/src/functionalTest/resources/test/only-helm-publish-plugin/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-    id 'io.github.gradle-cloud.helm-publish'
+    id 'io.github.build.extensions.oss.helm-publish'
 }


### PR DESCRIPTION
Change the name of organization - to avoid conflicts with Gradle trademarks