### PR TITLE
fix plugin gradle coordinates

### DIFF
--- a/.github/workflows/publish-documentation.yaml
+++ b/.github/workflows/publish-documentation.yaml
@@ -20,7 +20,7 @@ jobs:
     environment:
       # This job must only run in Publishing environment. It is protected from the majority of runs, which prevents Gradle secrets leakage
       name: Publishing
-      url: https://github.com/build.extensions.oss/gradle-helm-plugin/settings/environments/10298625189/edit
+      url: https://github.com/build-extensions-oss/gradle-helm-plugin/settings/environments/10298625189/edit
 
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle#using-the-gradle-starter-workflow

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     environment:
       # This job must only run in Publishing environment. It is protected from the majority of runs, which prevents Gradle secrets leakage
       name: Publishing
-      url: https://github.com/build.extensions.oss/gradle-helm-plugin/settings/environments/10298625189/edit
+      url: https://github.com/build-extensions-oss/gradle-helm-plugin/settings/environments/10298625189/edit
 
     steps:
       # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle#using-the-gradle-starter-workflow
@@ -56,7 +56,7 @@ jobs:
       - name: Publish the project
         # Several items:
         # 1. Secrets are uploaded via https://docs.github.com/en/actions/security-guides/encrypted-secrets
-        #    Correct them on https://github.com/build.extensions.oss/gradle-helm-plugin/settings/environments/10298625189/edit
+        #    Correct them on https://github.com/build-extensions-oss/gradle-helm-plugin/settings/environments/10298625189/edit
         #    Note!!!: these secrets must be in Publishing environment only
         # 2. We physically publish from master branch only. From other branches we can validate workflow.
         #    Please note - 'Publishing' environment is allowed to be used only in main branches, however that can be bypassed by admins (as expected) for publication testing

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
   <p align="center">
     <a href="https://citi.github.io/gradle-helm-plugin/"><img src="https://img.shields.io/badge/read%20our%20documentation-0f1632"></a>
-    <a href="https://plugins.gradle.org/plugin/io.github.build.extensions.oss.helm"><img src="https://img.shields.io/gradle-plugin-portal/v/io.github.build.extensions.oss.helm?colorA=0f1632&colorB=255be3" /></a>
+    <a href="https://plugins.gradle.org/plugin/io.github.build-extensions-oss.helm"><img src="https://img.shields.io/gradle-plugin-portal/v/io.github.build-extensions-oss.helm?colorA=0f1632&colorB=255be3" /></a>
     <a href="./LICENSE"><img src="https://img.shields.io/github/license/build-extensions-oss/gradle-helm-plugin?label=license&colorA=0f1632&colorB=255be3" /></a>
     <a href="https://img.shields.io/ossf-scorecard/github.com/build-extensions-oss/gradle-helm-plugin?label=openssf+scorecard&style=flat"><img src="https://img.shields.io/ossf-scorecard/github.com/Citi/gradle-helm-plugin?label=openssf+scorecard&style=flat" /></a>
   </p>
@@ -34,17 +34,17 @@
 
 ## Quick Start
 
-Add `io.github.build.extensions.oss.helm` to your Gradle project:
+Add `io.github.build-extensions-oss.helm` to your Gradle project:
 
 ```gradle
 plugins {
-    id 'io.github.build.extensions.oss.helm' version 'latest'
+    id 'io.github.build-extensions-oss.helm' version 'latest'
 }
 ```
 
 ```gradle
 plugins {
-    id("io.github.build.extensions.oss.helm") version "latest"
+    id("io.github.build-extensions-oss.helm") version "latest"
 }
 ```
 
@@ -64,7 +64,7 @@ plugins {
 This repository is a fork of [Citi/gradle-helm-plugin](https://github.com/Citi/gradle-helm-plugin), which is a
 of [unbroken-dome/gradle-helm-plugin](https://github.com/unbroken-dome/gradle-helm-plugin).
 
-The version [v2.2.0](https://github.com/build.extensions.oss/gradle-helm-plugin/releases/tag/v2.2.0) has exactly the same code
+The version [v2.2.0](https://github.com/build-extensions-oss/gradle-helm-plugin/releases/tag/v2.2.0) has exactly the same code
 with version [2.2.0](https://github.com/Citi/gradle-helm-plugin/releases/tag/2.2.0)
 of [Citi/gradle-helm-plugin](https://github.com/Citi/gradle-helm-plugin). Therefore, first please use that version. All
 Java/Kotlin packages are the same, so the plugin should be fully compatible.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,9 +6,9 @@
 # Consequences:
 # 1. We try to use matching prefixes/groups in the projects
 # 2. We copy-paste values in test to make them more independent. E.g. it is easier to read a small test than understanding our infrastructure.
-plugin.prefix=io.github.build.extensions.oss
+plugin.prefix=io.github.build-extensions-oss
 group=io.github.build.extensions.oss.helm
-github.url=https://github.com/build.extensions.oss/gradle-helm-plugin
+github.url=https://github.com/build-extensions-oss/gradle-helm-plugin
 
 version=0.0.1
 test.maxParallelForks=4

--- a/helm-publish-plugin/src/functionalTest/resources/test/artifactory-publish/build.gradle
+++ b/helm-publish-plugin/src/functionalTest/resources/test/artifactory-publish/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'io.github.build.extensions.oss.helm'
-    id 'io.github.build.extensions.oss.helm-publish'
+    id 'io.github.build-extensions-oss.helm'
+    id 'io.github.build-extensions-oss.helm-publish'
 }
 
 helm {

--- a/helm-publish-plugin/src/functionalTest/resources/test/only-helm-publish-plugin/build.gradle
+++ b/helm-publish-plugin/src/functionalTest/resources/test/only-helm-publish-plugin/build.gradle
@@ -1,3 +1,3 @@
 plugins {
-    id 'io.github.build.extensions.oss.helm-publish'
+    id 'io.github.build-extensions-oss.helm-publish'
 }


### PR DESCRIPTION
Fix Gradle Portal flag:

>The VCS URL is not matching with the pluginId. It is expected to start with "https://github.com/build/".

We should use dashes instead of dots.