### PR TITLE
sync group id

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@
 # 1. We try to use matching prefixes/groups in the projects
 # 2. We copy-paste values in test to make them more independent. E.g. it is easier to read a small test than understanding our infrastructure.
 plugin.prefix=io.github.build-extensions-oss
-group=io.github.build.extensions.oss.helm
+group=io.github.build-extensions-oss.helm
 github.url=https://github.com/build-extensions-oss/gradle-helm-plugin
 
 version=0.0.1


### PR DESCRIPTION
Fix error `Plugin ID 'io.github.build-extensions-oss.helm-commands' and group ID 'io.github.build.extensions.oss.helm' must use the same top level namespace, like 'io.github.build' or 'io.github.build-extensions-oss'`