### PR TITLE
build on Windows as well

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Mac OS and Windows are turned off: https://github.com/Citi/gradle-helm-plugin/issues/5
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, windows-latest ]
         jdk: [ 8, 11, 17 ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Try building on Windows as well. It seems like it works for now, because shell command doesn't fail on local Windows 11.