### PR TITLE
Migrate chart location

### DIFF
--- a/helm-releases-plugin/src/main/kotlin/io/github/build/extensions/oss/gradle/plugins/helm/release/dsl/ChartReference.kt
+++ b/helm-releases-plugin/src/main/kotlin/io/github/build/extensions/oss/gradle/plugins/helm/release/dsl/ChartReference.kt
@@ -38,7 +38,7 @@ internal class HelmChartReference(
 
 
     private val artifact: PublishArtifact
-        get() = configuration.artifacts.first()
+        get() = configuration.artifacts.single()
 
 
     override val chartLocation: String
@@ -85,9 +85,7 @@ internal class ConfigurationChartReference(
          * We have single artifact with single file, so let's use the API below.
          */
         get() = project.configurations.getByName(configurationName)
-            .incoming
             .artifacts
-            .artifactFiles
             .files
             .single()
             .absolutePath


### PR DESCRIPTION
Migrate from deprecated API to find the helm chart location.